### PR TITLE
Gh 17 write playstream events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ You can use the included Demo scene setup in `Scenes` to see how `godot-playfab`
 Only now you will see a new setting: `Playfab --> Title ID`
 
 ### Setting the Title Id
-* Got to [PlayFab](https://playfab.com), log in and copy your Title's ID
+* Go to [PlayFab](https://playfab.com), log in and copy your Title's ID
 * In your Godot editor, open Project Settings
 * Set the Title Id in `Playfab --> Title Id`
 
 ### Using `godot-playfab` in your Game
-First, you need to add a `PlayFab` node to your scene. When this is first used, it will create an encrypted `PlayFabConfig` file in `user://playfab_client_config.tres`. See the [File paths in Godot projects documentation](https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html).
+First, you need to add a `PlayFabClient` node to your scene. When this is first used, it will create an encrypted `PlayFabConfig` file in `user://playfab_client_config.tres`. See the [File paths in Godot projects documentation](https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html).
 
 This Config is used to store transient client data PlayFab needs to work across scenes, like the current PlayFab `Session Ticket`.
 
@@ -47,6 +47,8 @@ There are a few Signals that you can connect to:
 | registered        | Emitted when a new User is registered. You should only connect this in the Scene where you do Player Registrations.                                  |
 | logged_in         | Emitted when a Player successfully logs in.                                                                                                          |
 
+## Usage Guide & Examples
+See the [User Documentation](docs/user/README.md)
 
 ## Maintainer Documentation
 

--- a/Scenes/LoggedIn.gd
+++ b/Scenes/LoggedIn.gd
@@ -18,8 +18,51 @@ func update():
 func _on_Button_pressed():
 	var request_data = GetTitleDataRequest.new()
 #	request_data.Keys.append("BarKey")	# Would only get the key "BarKey"
-	$PlayFab.client_get_title_data(request_data, funcref(self, "_on_get_title_data"))
-	
+	$PlayFabClient.get_title_data(request_data, funcref(self, "_on_get_title_data"))
+
 
 func _on_get_title_data(response):
 	$VBoxContainer/Response.text = JSON.print(response.data, "\t")
+
+
+const EVENT_NAME_TELEMETRY = "title_player_telemetry_event"
+const EVENT_NAME_PLAYSTREAM = "title_player_playstream_event"
+
+func _on_BatchTelemetryEventsButton_pressed():
+	var payload = {
+		"Action": "_on_BatchTelemetryEventsButton_pressed"
+	}
+
+	$PlayFabEvent.batch_title_player_telemetry_event(EVENT_NAME_TELEMETRY, payload, funcref(self, "_on_write_events_request_completed"))
+
+
+func _on_BatchPlayStreamEventsButton_pressed():
+	var payload = {
+		"Action": "_on_BatchPlayStreamEventsButton_pressed"
+	}
+
+	$PlayFabEvent.batch_title_player_playstream_event(EVENT_NAME_PLAYSTREAM, payload, funcref(self, "_on_write_events_request_completed"))
+
+
+func _on_write_events_request_completed(response):
+	$VBoxContainer/Response.text = JSON.print(response.data, "\t")
+
+
+func _on_WriteTelemetryDirectButton_pressed():
+	var payload = {
+		"Action": "_on_WriteTelemetryDirectButton_pressed"
+	}
+
+	$PlayFabEvent.write_title_player_telemetry_event(EVENT_NAME_TELEMETRY, payload, funcref(self, "_on_write_events_request_completed"))
+
+
+func _on_WritePlayStreamDirectButton_pressed():
+	var payload = {
+		"Action": "_on_WritePlayStreamDirectButton_pressed"
+	}
+
+	$PlayFabEvent.write_title_player_playstream_event(EVENT_NAME_PLAYSTREAM, payload, funcref(self, "_on_write_events_request_completed"))
+
+
+func _on_PlayFab_api_error(error: ApiErrorWrapper):
+	print_debug(error.errorMessage)

--- a/Scenes/LoggedIn.tscn
+++ b/Scenes/LoggedIn.tscn
@@ -1,22 +1,17 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Scenes/LoggedIn.gd" type="Script" id=1]
-[ext_resource path="res://addons/godot-playfab/PlayFab.gd" type="Script" id=2]
+[ext_resource path="res://addons/godot-playfab/PlayFabEvent.gd" type="Script" id=2]
+[ext_resource path="res://addons/godot-playfab/PlayFabClient.gd" type="Script" id=3]
 
 [node name="Control" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="AccountPlayerId" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1024.0
@@ -205,14 +200,47 @@ margin_right = 1024.0
 margin_bottom = 216.0
 text = "Test Request"
 
-[node name="Response" type="RichTextLabel" parent="VBoxContainer"]
+[node name="BatchTelemetryEventsButton" type="Button" parent="VBoxContainer"]
 margin_top = 220.0
+margin_right = 1024.0
+margin_bottom = 240.0
+text = "Batch Telemetry Events"
+
+[node name="BatchPlayStreamEventsButton" type="Button" parent="VBoxContainer"]
+margin_top = 244.0
+margin_right = 1024.0
+margin_bottom = 264.0
+text = "Batch PlayStream Events"
+
+[node name="WriteTelemetryDirectButton" type="Button" parent="VBoxContainer"]
+margin_top = 268.0
+margin_right = 1024.0
+margin_bottom = 288.0
+text = "Write Telemetry Event (direct)"
+
+[node name="WritePlayStreamDirectButton" type="Button" parent="VBoxContainer"]
+margin_top = 292.0
+margin_right = 1024.0
+margin_bottom = 312.0
+text = "Write PlayStream Event (direct)"
+
+[node name="Response" type="RichTextLabel" parent="VBoxContainer"]
+margin_top = 316.0
 margin_right = 1024.0
 margin_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="PlayFab" type="Node" parent="."]
+[node name="PlayFabClient" type="Node" parent="."]
+script = ExtResource( 3 )
+
+[node name="PlayFabEvent" type="Node" parent="."]
 script = ExtResource( 2 )
 
 [connection signal="pressed" from="VBoxContainer/Button" to="." method="_on_Button_pressed"]
+[connection signal="pressed" from="VBoxContainer/BatchTelemetryEventsButton" to="." method="_on_BatchTelemetryEventsButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/BatchPlayStreamEventsButton" to="." method="_on_BatchPlayStreamEventsButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/WriteTelemetryDirectButton" to="." method="_on_WriteTelemetryDirectButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/WritePlayStreamDirectButton" to="." method="_on_WritePlayStreamDirectButton_pressed"]
+[connection signal="api_error" from="PlayFabClient" to="." method="_on_PlayFab_api_error"]
+[connection signal="api_error" from="PlayFabEvent" to="." method="_on_PlayFab_api_error"]

--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://Scenes/Main.gd" type="Script" id=1]
-[ext_resource path="res://addons/godot-playfab/PlayFab.gd" type="Script" id=2]
 
 [node name="Control" type="Control"]
 anchor_right = 1.0
@@ -38,9 +37,6 @@ margin_bottom = 92.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Login"
-
-[node name="PlayFab" type="Node" parent="."]
-script = ExtResource( 2 )
 
 [connection signal="pressed" from="Main/Register" to="Main" method="_on_Register_pressed"]
 [connection signal="pressed" from="Main/Login" to="Main" method="_on_Login_pressed"]

--- a/addons/godot-playfab/JsonSerializable.gd
+++ b/addons/godot-playfab/JsonSerializable.gd
@@ -7,16 +7,16 @@ func _get_type_for_property(property_name: String):
 	return ""
 
 func to_dict() -> Dictionary:
-	
+
 	var dict = {}
 	var props = get_property_list()
-	
+
 	# Skipping the first 3 items because they are metadata we do not need
 	for i in range(3, props.size()):
 		var prop = props[i]
 		var name = prop["name"] # The name of the property on the object. WIll be used to access its's value
 		var type = prop["type"]	# The godot built-in type (Array, Object etc)
-		
+
 		if (type == TYPE_OBJECT):
 			# Get the value of the property
 			var sub_prop = get(name)
@@ -30,28 +30,23 @@ func to_dict() -> Dictionary:
 				# No to_dict method - likely an error!
 				print_debug("if this is not a native object, pelase implement a to_dict method!")
 				dict[name] = sub_prop
-#		elif type == TYPE_ARRAY:
-#			var sub_dict = []
-#			for element in prop:
-#				sub_dict.append(element)
-#			dict[name] = sub_dict
 		else:
 			# Get the value of the property
 			dict[name] = get(name)
-	
+
 	return dict
 
 func from_dict(data: Dictionary, instance: JsonSerializable):
-	
+
 	var props = instance.get_property_list()
 	for key in data.keys():
-		
-		var type		
+
+		var type
 		for prop in props:
 			if prop["name"] == key:
 				type = prop["type"]
 				break
-		
+
 		# If basic data type - just set it
 		if type != TYPE_OBJECT:
 			instance.set(key, data[key])
@@ -69,7 +64,7 @@ func get_class_instance(name: String) -> Reference:
 	for element in classes:
 		if element["class"] == name:
 			return load(element["path"]).new()
-	
-	
+
+
 	push_error("Class \"" + name + "\" could not be found")
 	return null

--- a/addons/godot-playfab/JsonSerializable.gd
+++ b/addons/godot-playfab/JsonSerializable.gd
@@ -14,13 +14,29 @@ func to_dict() -> Dictionary:
 	# Skipping the first 3 items because they are metadata we do not need
 	for i in range(3, props.size()):
 		var prop = props[i]
-		var name = prop["name"]
-		var type = prop["type"]
+		var name = prop["name"] # The name of the property on the object. WIll be used to access its's value
+		var type = prop["type"]	# The godot built-in type (Array, Object etc)
 		
 		if (type == TYPE_OBJECT):
+			# Get the value of the property
 			var sub_prop = get(name)
-			dict[name] = sub_prop.to_dict()
+			if sub_prop == null:
+				# Actually set null if null
+				dict[name] = null
+			elif has_method("to_dict"):
+				# Handle recursive property
+				dict[name] = sub_prop.to_dict()
+			else:
+				# No to_dict method - likely an error!
+				print_debug("if this is not a native object, pelase implement a to_dict method!")
+				dict[name] = sub_prop
+#		elif type == TYPE_ARRAY:
+#			var sub_dict = []
+#			for element in prop:
+#				sub_dict.append(element)
+#			dict[name] = sub_dict
 		else:
+			# Get the value of the property
 			dict[name] = get(name)
 	
 	return dict

--- a/addons/godot-playfab/Models/AbstractJsonSerializableCollection.gd
+++ b/addons/godot-playfab/Models/AbstractJsonSerializableCollection.gd
@@ -1,22 +1,27 @@
+# This is a wrapper class around an Array
 extends JsonSerializable
 class_name AbstractJsonSerializableCollection
 
 
+# Holds the items
 var _Items: Array
 
 
+# Appends an element at the end of the array (alias of push_back).
 func append(item: JsonSerializable):
 	_Items.append(item)
 
 
+# Returns the number of elements in the array.
 func size() -> int:
 	return _Items.size()
 
-
+# Clears the array. This is equivalent to using resize with a size of 0.
 func clear():
 	_Items.clear();
 
 
+# Casts this collection and sub.objects to a Dictionary, recursively
 func to_dict() -> Dictionary:
 	var index = 0
 	var dict = []
@@ -26,6 +31,8 @@ func to_dict() -> Dictionary:
 
 	return dict
 
+
+# Rehydrates a collection and appropriate sub-objects from a Dictionary, recursively
 func from_dict(data: Dictionary, instance: JsonSerializable):
 	var index = 0
 	for item in data:

--- a/addons/godot-playfab/Models/AbstractJsonSerializableCollection.gd
+++ b/addons/godot-playfab/Models/AbstractJsonSerializableCollection.gd
@@ -1,0 +1,33 @@
+extends JsonSerializable
+class_name AbstractJsonSerializableCollection
+
+
+var _Items: Array
+
+
+func append(item: JsonSerializable):
+	_Items.append(item)
+
+
+func size() -> int:
+	return _Items.size()
+
+
+func clear():
+	_Items.clear();
+
+
+func to_dict() -> Dictionary:
+	var index = 0
+	var dict = []
+	for item in _Items:
+		dict.append((item as JsonSerializable).to_dict())
+		index += 1
+
+	return dict
+
+func from_dict(data: Dictionary, instance: JsonSerializable):
+	var index = 0
+	for item in data:
+		_Items.append(.from_dict(item, instance))
+		index += 1

--- a/addons/godot-playfab/Models/EntityKey.gd
+++ b/addons/godot-playfab/Models/EntityKey.gd
@@ -53,6 +53,6 @@ const ENTITY_TYPE_SERVICE = "service"
 # Unique ID of the entity.
 var Id: String
 
-# Entity type. See https://docs.microsoft.com/gaming/playfab/features/data/entities/available-built-in-entity-types
+# Entity type - one of ENTITY_TYPE_*. See https://docs.microsoft.com/gaming/playfab/features/data/entities/available-built-in-entity-types
 var Type: String
 

--- a/addons/godot-playfab/Models/EventContents.gd
+++ b/addons/godot-playfab/Models/EventContents.gd
@@ -1,0 +1,37 @@
+extends JsonSerializable
+class_name EventContents
+
+# The optional custom tags associated with the event (e.g. build number, external trace identifiers, etc.). Before an event is written, this collection and the base request custom tags will be merged, but not overriden. This enables the caller to specify static tags and per event tags.
+var CustomTags: Dictionary
+
+# Entity associated with the event. If null, the event will apply to the calling entity.
+# **You should not set the Entity** unless you need to.
+var Entity: EntityKey
+
+# The namespace in which the event is defined. Allowed namespaces can vary by API.
+var EventNamespace: String
+
+# The name of this event.
+var Name: String
+
+# The original unique identifier associated with this event before it was posted to PlayFab. The value might differ from the EventId value, which is assigned when the event is received by the server.
+var OriginalId: String
+
+# The time (in UTC) associated with this event when it occurred. If specified, this value is stored in the OriginalTimestamp property of the PlayStream event.
+var OriginalTimestamp: String
+
+# Arbitrary data associated with the event. `PayloadJSON` is not implemented.
+# If you ***need*** to use `PayloadJSON`, please use a verbaitim request instead.
+var Payload: Dictionary
+
+
+func _get_type_for_property(property_name: String) -> String:
+	match property_name:
+		"Entity":
+			return "EntityKey"
+		_:
+			pass
+
+	push_error("Could not find mapping for property: " + property_name)
+	return ._get_type_for_property(property_name)
+

--- a/addons/godot-playfab/Models/EventContentsCollection.gd
+++ b/addons/godot-playfab/Models/EventContentsCollection.gd
@@ -1,0 +1,2 @@
+extends AbstractJsonSerializableCollection
+class_name EventContentsCollection

--- a/addons/godot-playfab/Models/WriteEventsRequest.gd
+++ b/addons/godot-playfab/Models/WriteEventsRequest.gd
@@ -18,7 +18,7 @@ func _get_type_for_property(property_name: String) -> String:
 			return "EventContentsCollection"
 		_:
 			pass
-	
+
 	push_error("Could not find mapping for property: " + property_name)
 	return ._get_type_for_property(property_name)
-	
+

--- a/addons/godot-playfab/Models/WriteEventsRequest.gd
+++ b/addons/godot-playfab/Models/WriteEventsRequest.gd
@@ -1,0 +1,24 @@
+extends JsonSerializable
+class_name WriteEventsRequest
+
+# Collection of events to write to PlayStream.
+var Events: EventContentsCollection
+
+# The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.).
+var CustomTags: Dictionary
+
+
+func _init():
+	Events = EventContentsCollection.new()
+
+
+func _get_type_for_property(property_name: String) -> String:
+	match property_name:
+		"Events":
+			return "EventContentsCollection"
+		_:
+			pass
+	
+	push_error("Could not find mapping for property: " + property_name)
+	return ._get_type_for_property(property_name)
+	

--- a/addons/godot-playfab/PlayFab.gd
+++ b/addons/godot-playfab/PlayFab.gd
@@ -116,7 +116,15 @@ func _post_with_session_auth(body: JsonSerializable, path: String, callback: Fun
 	_http_request(HTTPClient.METHOD_POST, dict, path, callback, additional_headers)
 	return true
 
-
+# General request method for endpoints which require Entity-Token-Auth.
+# You should uset his to provide convenience methods for requests to specific resources.
+#
+# @visibility: internal
+# @param body: JsonSerializable						- A data model valid for the request to be made
+# @param path: String								- The request path, e.g. `/Client/GetTitleData`
+# @param callback: FuncRef							- A callback which will be called once teh request **succeeds**
+# @param additional_headers: Dictionary (optional)	- Additional headers to be sent with the request
+# @ returns: bool									- False if the player is not logged in - true if the rquest was sent.
 func _post_with_entity_auth(body: JsonSerializable, path: String, callback: FuncRef, additional_headers: Dictionary = {}) -> bool:
 	if !_playfab_client_config.is_logged_in():
 		push_error("Player is not logged in.")

--- a/addons/godot-playfab/PlayFab.gd
+++ b/addons/godot-playfab/PlayFab.gd
@@ -29,7 +29,7 @@ var _playfab_client_config: PlayFabClientConfig
 
 
 func _init():
-	
+
 	if ProjectSettings.has_setting(PlayFabConstants.SETTING_PLAYFAB_TITLE_ID) && ProjectSettings.get_setting(PlayFabConstants.SETTING_PLAYFAB_TITLE_ID) != "":
 		_title_id = ProjectSettings.get_setting(PlayFabConstants.SETTING_PLAYFAB_TITLE_ID)
 		_playfab_client_config = PlayFabClientConfig.new(_title_id)
@@ -42,11 +42,13 @@ func _ready():
 	_http = HTTPRequest.new()
 	add_child(_http)
 	connect("logged_in", self, "_on_logged_in")
-	
+
 
 func _on_logged_in(login_result: LoginResult):
 	# Setting SessionTicket for subsequent client requests
 	_playfab_client_config.session_ticket = login_result.SessionTicket
+	_playfab_client_config.master_player_account_id = login_result.PlayFabId
+	_playfab_client_config.entity_token = login_result.EntityToken
 
 
 func register_email_password(username: String, email: String, password: String, info_request_parameters: GetPlayerCombinedInfoRequestParams):
@@ -58,48 +60,48 @@ func register_email_password(username: String, email: String, password: String, 
 	request_params.Password = password
 	request_params.InfoRequestParameters = info_request_parameters
 	request_params.RequireBothUsernameAndEmail = true
-	
+
 	var result = _post(request_params, "/Client/RegisterPlayFabUser", funcref(self, "_on_register_email_password"))
 
 
 func login_with_email(email: String, password: String, custom_tags: Dictionary, info_request_parameters: GetPlayerCombinedInfoRequestParams):
 	_playfab_client_config.login_type = PlayFabClientConfig.LoginType.LOGIN_EMAIL
 	_playfab_client_config.login_id = email
-	
+
 	var request_params = LoginWithEmailAddressRequest.new()
 	request_params.TitleId = _title_id
 	request_params.Email = email
 	request_params.Password = password
 	request_params.CustomTags = custom_tags
 	request_params.InfoRequestParameters = info_request_parameters
-	
+
 	var result = _post(request_params, "/Client/LoginWithEmailAddress", funcref(self, "_on_login_with_email"))
 
 
 func login_with_custom_id(custom_id: String, create_user: bool, info_request_parameters: GetPlayerCombinedInfoRequestParams):
 	_playfab_client_config.login_type = PlayFabClientConfig.LoginType.LOGIN_CUSTOM_ID
 	_playfab_client_config.login_id = custom_id
-	
+
 	var request_params = LoginWithCustomIdRequest.new()
 	request_params.TitleId = _title_id
 	request_params.CustomId = custom_id
 	request_params.CreateAccount = create_user
 	request_params.InfoRequestParameters = info_request_parameters
-	
+
 	var result = _post(request_params, "/Client/LoginWithCustomID", funcref(self, "_on_login_with_email"))
 
 
 func _on_register_email_password(result: Dictionary):
 	var register_result = RegisterPlayFabUserResult.new()
 	register_result.from_dict(result["data"], register_result)
-		
+
 	emit_signal("registered", register_result)
 
 
 func _on_login_with_email(result: Dictionary):
 	var login_result = LoginResult.new()
 	login_result.from_dict(result["data"], login_result)
-	
+
 	emit_signal("logged_in", login_result)
 
 
@@ -110,6 +112,18 @@ func _post_with_session_auth(body: JsonSerializable, path: String, callback: Fun
 
 
 	additional_headers["X-Authorization"] = _playfab_client_config.session_ticket
+	var dict = body.to_dict()
+	_http_request(HTTPClient.METHOD_POST, dict, path, callback, additional_headers)
+	return true
+
+
+func _post_with_entity_auth(body: JsonSerializable, path: String, callback: FuncRef, additional_headers: Dictionary = {}) -> bool:
+	if !_playfab_client_config.is_logged_in():
+		push_error("Player is not logged in.")
+		return false
+
+
+	additional_headers["X-EntityToken"] = _playfab_client_config.entity_token.EntityToken
 	var dict = body.to_dict()
 	_http_request(HTTPClient.METHOD_POST, dict, path, callback, additional_headers)
 	return true
@@ -127,30 +141,31 @@ func _post_dict(body: Dictionary, path: String, callback: FuncRef, additional_he
 func _dict_to_header_array(dict: Dictionary):
 	if dict.size() < 1:
 		return []
-	
+
 	var array = []
 	for key in dict.keys():
 		var value = "%s: %s" % [key, dict[key]]
 		array.append(value)
-		
+
 	return array
 
 
 func _http_request(request_method: int, body: Dictionary, path: String, callback: FuncRef, additional_headers: Dictionary = {}):
 	var json = JSON.print(body)
+	#print_debug(JSON.print(body, "\t"))
 	var headers = ["Content-Type: application/json", "Content-Length: " + str(json.length())]
 	headers.append_array(_dict_to_header_array(additional_headers))
-	
+
 	while (_request_in_progress):
 		yield(_http.get_tree(), "idle_frame")
-	
+
 	_request_in_progress = true
 	var request_uri = "%s%s" % [ _playfab_client_config.api_url, path]
 	var error = _http.request(request_uri, headers, true, request_method, json)
 	if error != OK:
 		push_error("An error occurred in the HTTP request.")
 		return
-		
+
 	var args = yield(_http, "request_completed")
 	# TODO: Perhaps build response object?
 	var response_result = args[0]
@@ -158,11 +173,11 @@ func _http_request(request_method: int, body: Dictionary, path: String, callback
 	var response_headers = args[2]
 	var response_body = args[3]
 	_request_in_progress = false
-	
+
 	var response_body_string = response_body.get_string_from_utf8()
 	var json_parse_result = JSON.parse(response_body_string)
-	print_debug("JSON Parse result: %s" % JSON.print(json_parse_result.result, "\t"))
-		
+	#print_debug("JSON Parse result: %s" % JSON.print(json_parse_result.result, "\t"))
+
 	if json_parse_result.error != OK:
 		emit_signal("json_parse_error", json_parse_result)
 		return
@@ -178,10 +193,6 @@ func _http_request(request_method: int, body: Dictionary, path: String, callback
 	if response_code >= 500:
 		emit_signal("server_error", path)
 		return
-
-
-func client_get_title_data(request_data: GetTitleDataRequest, callback: FuncRef):
-	_post_with_session_auth(request_data, "/Client/GetTitleData", callback)
 
 
 func _test_http(body, path: String):

--- a/addons/godot-playfab/PlayFabClient.gd
+++ b/addons/godot-playfab/PlayFabClient.gd
@@ -1,6 +1,8 @@
 extends PlayFab
 class_name PlayFabClient, "res://addons/godot-playfab/icon.png"
 
-
+# Retrieves the key-value store of custom title settings
+# @param request_data: GetTitleDataRequest
+# @param callback: FuncRef
 func get_title_data(request_data: GetTitleDataRequest, callback: FuncRef):
 	_post_with_session_auth(request_data, "/Client/GetTitleData", callback)

--- a/addons/godot-playfab/PlayFabClient.gd
+++ b/addons/godot-playfab/PlayFabClient.gd
@@ -1,0 +1,6 @@
+extends PlayFab
+class_name PlayFabClient, "res://addons/godot-playfab/icon.png"
+
+
+func get_title_data(request_data: GetTitleDataRequest, callback: FuncRef):
+	_post_with_session_auth(request_data, "/Client/GetTitleData", callback)

--- a/addons/godot-playfab/PlayFabClientConfig.gd
+++ b/addons/godot-playfab/PlayFabClientConfig.gd
@@ -2,6 +2,7 @@ extends Reference
 class_name PlayFabClientConfig, "res://addons/godot-playfab/icon.png"
 
 
+const DEBUG_DO_NOT_ENCRYPT = false	# Only works on debug builds
 const CONFIG_LOAD_PATH = "user://playfab_client_config.cfg"
 const SECTION_NAME = "PlayFab"
 
@@ -11,7 +12,17 @@ var password
 var title_id setget set_title_id
 var base_uri = "playfabapi.com"
 var api_url
+
+## The Client Session ticket. Used for /Client API
 var session_ticket = "" setget set_session_ticket,get_session_ticket
+
+## The Master Player Account ID, aka "PlayFab ID"
+var master_player_account_id setget set_master_player_account_id,get_master_player_account_id
+
+## Object holding the Entity Token, as well as the EntityKey (ID, Type) of the logged in Entity (usually title_player_account)
+var entity_token : EntityTokenResponse setget set_entity_token,get_entity_token
+
+
 var initialized = false
 var login_type = LoginType.LOGIN_NONE
 
@@ -19,6 +30,7 @@ var login_type = LoginType.LOGIN_NONE
 ## LOGIN_EMAIL - Email
 ## LOGIN_CUSTOM_ID - UUID
 var login_id = "" setget set_login_id
+
 
 enum LoginType {
 	LOGIN_NONE,
@@ -47,6 +59,24 @@ func get_session_ticket() -> String:
 	return session_ticket
 
 
+func set_master_player_account_id(id: String):
+	master_player_account_id = id
+	_save_config()
+
+
+func get_master_player_account_id() -> String:
+	return master_player_account_id
+
+
+func set_entity_token(token: EntityTokenResponse):
+	entity_token = token
+	_save_config()
+
+
+func get_entity_token() -> EntityTokenResponse:
+	return entity_token
+
+
 func set_login_id(value):
 	login_id = value
 
@@ -63,22 +93,33 @@ func is_logged_in() -> bool:
 
 func _save_config():
 	_config.set_value(SECTION_NAME, "session_ticket", session_ticket)
+	_config.set_value(SECTION_NAME, "master_player_account_id", master_player_account_id)
+	_config.set_value(SECTION_NAME, "entity_token", entity_token)
 	_config.set_value(SECTION_NAME, "login_id", login_id)
 	_config.set_value(SECTION_NAME, "login_type", login_type)
-	
-	_config.save_encrypted_pass(CONFIG_LOAD_PATH, password)
+
+	if OS.is_debug_build() && DEBUG_DO_NOT_ENCRYPT:
+		_config.save(CONFIG_LOAD_PATH)
+	else:
+		_config.save_encrypted_pass(CONFIG_LOAD_PATH, password)
 
 
 func _load_config():
 	_config = ConfigFile.new()
-	var err = _config.load_encrypted_pass(CONFIG_LOAD_PATH, password)
-	
+	var err: int
+	if OS.is_debug_build() && DEBUG_DO_NOT_ENCRYPT:
+		err = _config.load(CONFIG_LOAD_PATH)
+	else:
+		err = _config.load_encrypted_pass(CONFIG_LOAD_PATH, password)
+
 	# If the file didn't load, ignore it.
 	if err != OK:
 		print_debug("Config file didn't load. Error code: %f" % err)
 		return
-		
+
 	initialized = true
 	session_ticket = _config.get_value(SECTION_NAME, "session_ticket")
+	master_player_account_id = _config.get_value(SECTION_NAME, "master_player_account_id")
+	entity_token = _config.get_value(SECTION_NAME, "entity_token")
 	login_id = _config.get_value(SECTION_NAME, "login_id")
 	login_type = _config.get_value(SECTION_NAME, "login_type")

--- a/addons/godot-playfab/PlayFabEvent.gd
+++ b/addons/godot-playfab/PlayFabEvent.gd
@@ -1,0 +1,139 @@
+extends PlayFab
+class_name PlayFabEvent, "res://addons/godot-playfab/icon.png"
+
+
+
+## Emitted when the PlayStream Event batch was flushed
+## @param event_ids: The IDs of the events written
+signal event_batch_playstream_flushed(event_ids)
+
+## Emitted when the Telemetry Event batch was flushed
+## @param event_ids: The IDs of the events written
+signal event_batch_telemetry_flushed(event_ids)
+
+
+export(int) var event_batch_size = 5
+export(int) var event_batch_timeout_seconds = 10
+
+
+var playstream_event_batch = EventContentsCollection.new()
+var telemetry_event_batch = EventContentsCollection.new()
+
+func _ready():
+	var timer = Timer.new()
+	timer.process_mode = Timer.TIMER_PROCESS_IDLE
+	timer.wait_time = event_batch_timeout_seconds
+	timer.one_shot = false
+	timer.autostart = true
+	timer.connect("timeout", self, "_flush_playstream_event_batch")
+	timer.connect("timeout", self, "_flush_telemetry_event_batch")
+	add_child(timer)
+
+
+func _process(_delta):
+	check_event_batch_sizes()
+
+
+func event_telemetry_write_events(request_data: WriteEventsRequest, callback: FuncRef):
+	_post_with_entity_auth(request_data, "/Event/WriteTelemetryEvents", callback)
+
+
+func event_playstream_write_events(request_data: WriteEventsRequest, callback: FuncRef):
+	_post_with_entity_auth(request_data, "/Event/WriteEvents", callback)
+
+
+# Directly write a Telemetry Event
+func write_title_player_telemetry_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
+	var event = assemble_event(event_name, payload, event_namespace)
+	# We send a batch of events here!
+	var request = WriteEventsRequest.new()
+	request.Events.append(event)
+	event_telemetry_write_events(request, callback)
+
+
+# Directly write a PlayStream Event
+func write_title_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
+	var event = assemble_event(event_name, payload, event_namespace)
+	# We send a batch of events here!
+	var request = WriteEventsRequest.new()
+	request.Events.append(event)
+	event_playstream_write_events(request, callback)
+
+
+func batch_title_player_telemetry_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
+	var event = assemble_event(event_name, payload, event_namespace)
+	telemetry_event_batch.append(event)
+
+
+func batch_title_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
+	var event = assemble_event(event_name, payload, event_namespace)
+	playstream_event_batch.append(event)
+
+
+func assemble_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id) -> EventContents:
+	var event = EventContents.new()
+	event.Name = event_name
+	event.EventNamespace = event_namespace
+	event.Payload = payload
+	# Event can also have an Entity, which is a type/id combo.
+	# If omitted, the event will be sent in the "current" Entity's context
+	# Usually, this means `title_player_account`, as you are logged in with it in a client.
+
+	return event
+
+
+## Batch a PlayStream Event as master_player_account
+## WILL NOT WORK IN A REGULAR CLIENT! As you only have a title_player_account token
+func batch_master_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
+	var event = EventContents.new()
+	event.Name = event_name
+	event.EventNamespace = event_namespace
+	event.Payload = payload
+	var entity = EntityKey.new()
+	if _playfab_client_config.is_logged_in(): # Needed, also loads the config. If not logged in, willl use the current Entity
+		entity.Id = _playfab_client_config.master_player_account_id
+		entity.Type = EntityKey.ENTITY_TYPE_MASTER_PLAYER_ACCOUNT
+		event.Entity = entity
+	playstream_event_batch.append(event)
+
+
+func check_event_batch_sizes():
+	if playstream_event_batch.size() >= event_batch_size:
+		_flush_playstream_event_batch()
+	elif telemetry_event_batch.size() >= event_batch_size:
+		_flush_telemetry_event_batch()
+
+
+func _flush_playstream_event_batch():
+	if playstream_event_batch.size() < 1:
+		print_debug("No telemetry events to flush")
+		return
+
+	var request = WriteEventsRequest.new()
+	request.Events = playstream_event_batch
+	event_playstream_write_events(request, funcref(self, "_on_playstream_batch_flush"))
+	playstream_event_batch.clear()
+	print_debug("Flushed playstream batch")
+
+func _flush_telemetry_event_batch():
+	if telemetry_event_batch.size() < 1:
+		print_debug("No playstream events to flush")
+		return
+
+	var request = WriteEventsRequest.new()
+	request.Events = telemetry_event_batch
+	event_telemetry_write_events(request, funcref(self, "_on_telemetry_batch_flush"))
+	telemetry_event_batch.clear()
+	print_debug("Flushed telemetry batch")
+
+
+func _on_playstream_batch_flush(response: Dictionary):
+	var event_ids: Array = response["data"]["AssignedEventIds"]
+	print_debug("Flushed %s PlayStream events" % event_ids.size())
+	emit_signal("event_batch_playstream_flushed", event_ids)
+
+
+func _on_telemetry_batch_flush(response: Dictionary):
+	var event_ids: Array = response["data"]["AssignedEventIds"]
+	print_debug("Flushed %s Telemetry events" % event_ids.size())
+	emit_signal("event_batch_telemetry_flushed", event_ids)

--- a/addons/godot-playfab/PlayFabEvent.gd
+++ b/addons/godot-playfab/PlayFabEvent.gd
@@ -3,16 +3,18 @@ class_name PlayFabEvent, "res://addons/godot-playfab/icon.png"
 
 
 
-## Emitted when the PlayStream Event batch was flushed
-## @param event_ids: The IDs of the events written
+# Emitted when the PlayStream Event batch was flushed
+# @param event_ids: The IDs of the events written
 signal event_batch_playstream_flushed(event_ids)
 
-## Emitted when the Telemetry Event batch was flushed
-## @param event_ids: The IDs of the events written
+# Emitted when the Telemetry Event batch was flushed
+# @param event_ids: The IDs of the events written
 signal event_batch_telemetry_flushed(event_ids)
 
-
+# Defines the event batch size threshold
 export(int) var event_batch_size = 5
+
+# Defines the wait time (in seconds) until batches are flushed
 export(int) var event_batch_timeout_seconds = 10
 
 
@@ -31,20 +33,22 @@ func _ready():
 
 
 func _process(_delta):
-	check_event_batch_sizes()
+	_flush_batches_on_batch_size_met()
 
 
+# Write batches of entity based events to as Telemetry events (bypass PlayStream). The namespace must be 'custom' or start with 'custom.'
 func event_telemetry_write_events(request_data: WriteEventsRequest, callback: FuncRef):
 	_post_with_entity_auth(request_data, "/Event/WriteTelemetryEvents", callback)
 
 
+# Write batches of entity based events to PlayStream. The namespace of the Event must be 'custom' or start with 'custom.'.
 func event_playstream_write_events(request_data: WriteEventsRequest, callback: FuncRef):
 	_post_with_entity_auth(request_data, "/Event/WriteEvents", callback)
 
 
 # Directly write a Telemetry Event
 func write_title_player_telemetry_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
-	var event = assemble_event(event_name, payload, event_namespace)
+	var event = _assemble_event(event_name, payload, event_namespace)
 	# We send a batch of events here!
 	var request = WriteEventsRequest.new()
 	request.Events.append(event)
@@ -53,24 +57,27 @@ func write_title_player_telemetry_event(event_name: String, payload: Dictionary,
 
 # Directly write a PlayStream Event
 func write_title_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
-	var event = assemble_event(event_name, payload, event_namespace)
+	var event = _assemble_event(event_name, payload, event_namespace)
 	# We send a batch of events here!
 	var request = WriteEventsRequest.new()
 	request.Events.append(event)
 	event_playstream_write_events(request, callback)
 
 
+# Batch a Telemetry Event for later sending
 func batch_title_player_telemetry_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
-	var event = assemble_event(event_name, payload, event_namespace)
+	var event = _assemble_event(event_name, payload, event_namespace)
 	telemetry_event_batch.append(event)
 
 
+# Batch a PlayStream Event for later sending
 func batch_title_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
-	var event = assemble_event(event_name, payload, event_namespace)
+	var event = _assemble_event(event_name, payload, event_namespace)
 	playstream_event_batch.append(event)
 
-
-func assemble_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id) -> EventContents:
+# Assembles event data
+# @Visivbility: Private
+func _assemble_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id) -> EventContents:
 	var event = EventContents.new()
 	event.Name = event_name
 	event.EventNamespace = event_namespace
@@ -82,28 +89,16 @@ func assemble_event(event_name: String, payload: Dictionary, callback: FuncRef, 
 	return event
 
 
-## Batch a PlayStream Event as master_player_account
-## WILL NOT WORK IN A REGULAR CLIENT! As you only have a title_player_account token
-func batch_master_player_playstream_event(event_name: String, payload: Dictionary, callback: FuncRef, event_namespace = "custom.%s" % _title_id):
-	var event = EventContents.new()
-	event.Name = event_name
-	event.EventNamespace = event_namespace
-	event.Payload = payload
-	var entity = EntityKey.new()
-	if _playfab_client_config.is_logged_in(): # Needed, also loads the config. If not logged in, willl use the current Entity
-		entity.Id = _playfab_client_config.master_player_account_id
-		entity.Type = EntityKey.ENTITY_TYPE_MASTER_PLAYER_ACCOUNT
-		event.Entity = entity
-	playstream_event_batch.append(event)
-
-
-func check_event_batch_sizes():
+# Tiggers batch flush if comfigured treshold is met
+# @Visivbility: Private
+func _flush_batches_on_batch_size_met():
 	if playstream_event_batch.size() >= event_batch_size:
 		_flush_playstream_event_batch()
 	elif telemetry_event_batch.size() >= event_batch_size:
 		_flush_telemetry_event_batch()
 
-
+# Flushes the PlayStream event batch
+# @Visivbility: Private
 func _flush_playstream_event_batch():
 	if playstream_event_batch.size() < 1:
 		print_debug("No telemetry events to flush")
@@ -115,6 +110,9 @@ func _flush_playstream_event_batch():
 	playstream_event_batch.clear()
 	print_debug("Flushed playstream batch")
 
+
+# Flushes the Telemetry event batch
+# @Visivbility: Private
 func _flush_telemetry_event_batch():
 	if telemetry_event_batch.size() < 1:
 		print_debug("No playstream events to flush")
@@ -127,12 +125,16 @@ func _flush_telemetry_event_batch():
 	print_debug("Flushed telemetry batch")
 
 
+# Callback for after PlayStream batch flush
+# @Visivbility: Private
 func _on_playstream_batch_flush(response: Dictionary):
 	var event_ids: Array = response["data"]["AssignedEventIds"]
 	print_debug("Flushed %s PlayStream events" % event_ids.size())
 	emit_signal("event_batch_playstream_flushed", event_ids)
 
 
+# Callback for after Telemetry batch flush
+# @Visivbility: Private
 func _on_telemetry_batch_flush(response: Dictionary):
 	var event_ids: Array = response["data"]["AssignedEventIds"]
 	print_debug("Flushed %s Telemetry events" % event_ids.size())

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,28 @@ Open a model definition in the browser and fill in title and data according to t
 This will not always generate perfect models. Specifically Type hints are likely to not compile. Either because there was an oversight on implementing the Model Creator, or because the docs are broken or you need to create another, downstream Model.
 
 While it is not perfect, it still saves a *ton* of time.
+
+
+## Implementing a Model with an Array of Objects
+Some Request models have properties, which are arrays of Objects.
+
+<div style="color: indianred">If the elements in this array will be custom classes in Godot, serialization of them will <b><u>fail</u></b>!</div>
+
+In order for them to correctly serialize, you need to do the following steps:
+
+1. Create a new Class, inheriting from `AbstractJsonSerializableCollection`. It does not need to carry any further implementation. Example:
+    ````gdscript
+    extends AbstractJsonSerializableCollection
+    class_name EventContentsCollection
+    ````
+2. Instead of an `Array`, the property should use the newly created collection class. See the `Events` property below:
+    ````gdscript
+    extends JsonSerializable
+    class_name WriteEventsRequest
+    
+    # Collection of events to write to PlayStream.
+    var Events: EventContentsCollection    
+    
+    func _init():
+        Events = EventContentsCollection.new()
+    ````

--- a/docs/user/Events/Configuration.md
+++ b/docs/user/Events/Configuration.md
@@ -13,7 +13,7 @@ In order for you to be able to flexibly change those based on your needs whereve
 
 > If you use multiple `PlayFab` nodes, you may set these values independently
 
-Suppose you want to implement a logger of which sends Telemetry Events for debugging purposes, but also write general PlayStream events to react upon.
+Suppose you want to implement a logger of which sends Telemetry Events for debugging purposes. But you would also like to write general PlayStream events to react upon.
 You could then configure two different `PlayFab` objects with different batching configurations.
 
 ### Example:

--- a/docs/user/Events/Configuration.md
+++ b/docs/user/Events/Configuration.md
@@ -1,0 +1,36 @@
+# Configuration for Events
+When sending events, you may want to batch batch requests you send to save on API requests/open connections.
+
+In order for you to be able to flexibly change those based on your needs wherever you are in your game, each `PlayFab` node exposes two settings:
+
+| Name                | Variable                    | Description                                                                                       |
+|---------------------|-----------------------------|---------------------------------------------------------------------------------------------------|
+| Event Batch Size    | event_batch_size            | Determines how many events are batched before they are sent automatically                         |
+| Event Batch Timeout | event_batch_timeout_seconds | Determines after how many seconds the batch will be flushed - disregarding the current batch size |
+
+## Considerations
+> If your game crashes while having batched, unsent events, these will be lost!
+
+> If you use multiple `PlayFab` nodes, you may set these values independently
+
+Suppose you want to implement a logger of which sends Telemetry Events for debugging purposes, but also write general PlayStream events to react upon.
+You could then configure two different `PlayFab` objects with different batching configurations.
+
+### Example:
+#### Logger
+Log Telemetry Events immediately
+
+| Name                | Value        |
+|---------------------|--------------|
+| Event Batch Size    | 1            |
+| Event Batch Timeout | 10 (default) |
+
+#### PlayStream Events
+Sending small PlayStream events, we don't really care when/if they are being sent
+
+| Name                | Value        |
+|---------------------|--------------|
+| Event Batch Size    | 5 (default)  |
+| Event Batch Timeout | 10 (default) |
+
+Back: [Events - PlayStream & Telemetry](README.md) | Next: [Flushing Events](Flushing.md)

--- a/docs/user/Events/Flushing.md
+++ b/docs/user/Events/Flushing.md
@@ -1,0 +1,17 @@
+# Flushing Events
+Events will be automatically sent if either of the thresholds in the [Conifguration](./Configuration.md) is met.
+
+However, you can also force flush the cache:
+
+
+## Flush Telemetry Event Batch
+````gdscript
+$PlayFab._flush_telemetry_event_batch()
+````
+
+## Flush PlayStream Event Batch
+````gdscript
+$PlayFab._flush_playstream_event_batch()
+````
+
+Back: [Configuration for Events](Configuration.md) | Next: [Flushing Events](Flushing.md)

--- a/docs/user/Events/README.md
+++ b/docs/user/Events/README.md
@@ -1,0 +1,35 @@
+# Events - PlayStream & Telemetry
+> See the [Official Documentation](https://docs.microsoft.com/en-us/gaming/playfab/features/automation/playstream-events/)
+
+PlayStream and Telemetry events are - from a integration perspective - the same.
+The only difference when sending either event type is the different API name.
+
+**The difference is in pricing!**
+
+## TL;DR; - what should I use?
+Telemetry Events - unless you need to react upon these events in near-real-time.
+Telemetry Events are a lot less expensive!
+
+## Differences
+### PlayStream Events
+
+PlayStream events...
+* Near-real-time
+* will appear in the GameStream
+* can be reacted upon e.g.
+    * execute script
+    * send notification
+    * give item etc.
+* Can be worked with in the Data & Analytics features of PlayFab
+* Cost **more than double** than Telemetry events!
+* Otherwise have the same properties as Telemetry Events
+
+
+### Telemetry Events
+* Bypass the PlayStream
+* Can be worked with in the Data & Analytics features of PlayFab
+
+# Usage
+Instead of a `PlayFabClient` Node, drop a `PlayFabEvent` node in your scene!
+
+Back: [User Documentation](../README.md) | Next: [Configuration for Events](Configuration.md) 

--- a/docs/user/Events/Sending.md
+++ b/docs/user/Events/Sending.md
@@ -1,0 +1,70 @@
+# Sending Events
+
+There are multiple ways of how you can write events:
+
+* Batched Send
+* Direct write
+
+## Batched Send
+should be used if you either want to:
+* Save HTTP overhead traffic (by sending fewer individual event write requests)
+* Ingest large numbers of events
+
+PlayFab has API limits for # of requests and size of events.
+Thus, it is **generally recommended** to batch events as much as possible to future-proof your game.
+
+### Batching Defaults
+However, `godot-playfab` sets defaults default on batch-sending to provide an easy to sue user experience for game developers.
+You can change these defaults to fit your needs - see [Configuration](Configuration.md).
+
+
+## Direct Write
+should only be used if you:
+* need to immediately send an event
+* are sure you are not sending too many events
+
+# API
+The [PlayFabEvent](/addons/godot-playfab/PlayFabEvent.gd) Node class covers the PlayFab Event API.
+
+Examples below assume:
+```gdscript
+var payload = {
+    "foo": "bar"
+}
+var event_name = "title_player_event"
+var callback = "_on_write_events_request_completed"
+```
+
+## Batched Send
+> **Note**
+>
+> Events will be first batched, and only sent when:
+> * a [configured Flush Threshold](Configuration.md) is met , or
+> * the batch is [flushed manually](Flushing.md).
+>
+### Telemetry Event
+Batch a Telemetry Event:
+```gdscript
+$PlayFabEvent.batch_title_player_telemetry_event(event_name, payload, funcref(self, callback))
+```
+
+### PlayStream Event
+Batch a PlayStream Event:
+```gdscript
+$PlayFabEvent.batch_title_player_playstream_event(event_name, payload, funcref(self, callback))
+```
+
+
+## Direct Write
+
+### Telemetry Event
+Write a Telemetry Event:
+````gdscript
+$PlayFabEvent.write_title_player_telemetry_event(event_name, payload, funcref(self, callback))
+````
+
+### PlayStream Event
+Write a PlayStream Event:
+````gdscript
+$PlayFabEvent.write_title_player_playstream_event(event_name, payload, funcref(self, callback))
+````

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,5 @@
+# User Documentation
+This is the "user" or "game developer" documentation - if you are a developer seeking to *integrate* `godot-playfab`, this is for you!
+
+# Topics
+* [Events](Events/Index.md)

--- a/project.godot
+++ b/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "JsonSerializable",
+"class": "AbstractJsonSerializableCollection",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/Models/AbstractJsonSerializableCollection.gd"
+}, {
 "base": "Reference",
 "class": "ApiErrorWrapper",
 "language": "GDScript",
@@ -23,6 +28,16 @@ _global_script_classes=[ {
 "class": "EntityTokenResponse",
 "language": "GDScript",
 "path": "res://addons/godot-playfab/Models/EntityTokenResponse.gd"
+}, {
+"base": "JsonSerializable",
+"class": "EventContents",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/Models/EventContents.gd"
+}, {
+"base": "AbstractJsonSerializableCollection",
+"class": "EventContentsCollection",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/Models/EventContentsCollection.gd"
 }, {
 "base": "JsonSerializable",
 "class": "GetPlayerCombinedInfoRequestParams",
@@ -74,6 +89,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-playfab/PlayFab.gd"
 }, {
+"base": "PlayFab",
+"class": "PlayFabClient",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/PlayFabClient.gd"
+}, {
 "base": "Reference",
 "class": "PlayFabClientConfig",
 "language": "GDScript",
@@ -83,6 +103,11 @@ _global_script_classes=[ {
 "class": "PlayFabConstants",
 "language": "GDScript",
 "path": "res://addons/godot-playfab/PlayFabConstants.gd"
+}, {
+"base": "PlayFab",
+"class": "PlayFabEvent",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/PlayFabEvent.gd"
 }, {
 "base": "JsonSerializable",
 "class": "PlayerProfileViewConstraints",
@@ -113,11 +138,19 @@ _global_script_classes=[ {
 "class": "UserTitleInfo",
 "language": "GDScript",
 "path": "res://addons/godot-playfab/Models/UserTitleInfo.gd"
+}, {
+"base": "JsonSerializable",
+"class": "WriteEventsRequest",
+"language": "GDScript",
+"path": "res://addons/godot-playfab/Models/WriteEventsRequest.gd"
 } ]
 _global_script_class_icons={
+"AbstractJsonSerializableCollection": "",
 "ApiErrorWrapper": "",
 "EntityKey": "",
 "EntityTokenResponse": "",
+"EventContents": "",
+"EventContentsCollection": "",
 "GetPlayerCombinedInfoRequestParams": "",
 "GetPlayerCombinedInfoResultPayload": "",
 "GetTitleDataRequest": "",
@@ -128,14 +161,17 @@ _global_script_class_icons={
 "LoginWithCustomIdRequest": "",
 "LoginWithEmailAddressRequest": "",
 "PlayFab": "res://addons/godot-playfab/icon.png",
+"PlayFabClient": "res://addons/godot-playfab/icon.png",
 "PlayFabClientConfig": "res://addons/godot-playfab/icon.png",
 "PlayFabConstants": "",
+"PlayFabEvent": "",
 "PlayerProfileViewConstraints": "",
 "RegisterPlayFabUserRequest": "",
 "RegisterPlayFabUserResult": "",
 "UUID": "",
 "UserAccountInfo": "",
-"UserTitleInfo": ""
+"UserTitleInfo": "",
+"WriteEventsRequest": ""
 }
 
 [application]

--- a/project.godot
+++ b/project.godot
@@ -164,7 +164,7 @@ _global_script_class_icons={
 "PlayFabClient": "res://addons/godot-playfab/icon.png",
 "PlayFabClientConfig": "res://addons/godot-playfab/icon.png",
 "PlayFabConstants": "",
-"PlayFabEvent": "",
+"PlayFabEvent": "res://addons/godot-playfab/icon.png",
 "PlayerProfileViewConstraints": "",
 "RegisterPlayFabUserRequest": "",
 "RegisterPlayFabUserResult": "",


### PR DESCRIPTION
Implements #17 

- [x] Implement Entity authentication
- [x] Make `Entity` of an `EventContents` nullable. Serialization seems to fail on this
- [x] See how we can implement both `Payload` and `PayloadJSON` on `EventContents` - but ensure only one is transmitted
- [x] Think about adding individual requests for different entity types
- [x] Implement an AbstractArrayCollection based on the current implementation of `EventContentsCollection`
- [x] Batch-send events on configurable timer
- [x] Flush batch on crash - blocked by https://github.com/godotengine/godot-proposals/issues/1896
- [x] Add Documentation on how to use PlayStream/Telemetry events