### PR TITLE
Fixed: PlayFabEvent._assemble_event() - removed callback

### DIFF
--- a/addons/godot-playfab/PlayFabEvent.gd
+++ b/addons/godot-playfab/PlayFabEvent.gd
@@ -114,7 +114,7 @@ func batch_title_player_playstream_event(event_name: String, payload: Dictionary
 # @param payload: Dictionary - A dictionary to send as event payload
 # @param callback: FuncRef (= nulloptional) - A callback, providing a Dictionary containing the Event ID.
 # @param event_namespace: String (optional) - The namespace of the Event must be 'custom' or start with 'custom.'.
-func _assemble_event(event_name: String, payload: Dictionary, callback: FuncRef = null, event_namespace = "custom.%s" % _title_id) -> EventContents:
+func _assemble_event(event_name: String, payload: Dictionary, event_namespace = "custom.%s" % _title_id) -> EventContents:
 	var event = EventContents.new()
 	event.Name = event_name
 	event.EventNamespace = event_namespace

--- a/addons/godot-playfab/test/unit/test_PlayFabEvent.gd
+++ b/addons/godot-playfab/test/unit/test_PlayFabEvent.gd
@@ -1,0 +1,32 @@
+extends "res://addons/gut/test.gd"
+
+
+func before_each():
+	gut.p("ran setup", 2)
+
+func after_each():
+	gut.p("ran teardown", 2)
+
+func before_all():
+	gut.p("ran run setup", 2)
+
+func after_all():
+	gut.p("ran run teardown", 2)
+
+func test__assemble_event_returns_event_with_properties_according_to_parameters():
+	var playfab_event = PlayFabEvent.new()
+	var event_name = "my event name"
+	var event_payload = {"foo" : "1" }
+	var event_namespace = "my_event_namespace"
+	
+	var event = playfab_event._assemble_event(event_name, event_payload, event_namespace)
+	
+	var expected_event_contents = EventContents.new()
+	expected_event_contents.Name = event_name
+	expected_event_contents.Payload = event_payload
+	expected_event_contents.EventNamespace = event_namespace
+
+	assert_is(event, EventContents)
+	assert_eq(event.Name, expected_event_contents.Name)
+	assert_eq(event.Payload, expected_event_contents.Payload)
+	assert_eq(event.EventNamespace, expected_event_contents.EventNamespace)	


### PR DESCRIPTION
Fixed: PlayFabEvent._assemble_event() did not properly accept the `eevent_namespace` parameter.