### PR TITLE
fix: Implementation to check for GZip Accept-Encoding header 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,11 @@ jobs:
       - uses: actions/checkout@v3
 
       # Run Godot Tests with GUT (https://github.com/bitwes/Gut)
-      - uses: croconut/godot-tester@v2.5
+      - name: Run Godot 3.4.4 Tests
+        uses: croconut/godot-tester@v2.5
         with:
           # required
-          version: "3.4.4"
+          version: "3.5"
           # the type of release of godot that the tests should be run with
           release_type: "stable"
           is-mono: "false"
@@ -71,11 +72,11 @@ jobs:
           # default is GUTs default: 'res://.gutconfig.json'; set this to load a different config file
           config-file: "res://.gutconfig.json"
 
-
-      - uses: croconut/godot-tester@v2.5
+      - name: Run Godot 3.4.4 Tests
+        uses: croconut/godot-tester@v2.5
         with:
           # required
-          version: "3.5"
+          version: "3.4.4"
           # the type of release of godot that the tests should be run with
           release_type: "stable"
           is-mono: "false"

--- a/addons/godot-playfab/PlayFabHttp.gd
+++ b/addons/godot-playfab/PlayFabHttp.gd
@@ -76,8 +76,14 @@ func _http_request(request_method: int, body: Dictionary, path: String, callback
 	_request_in_progress = false
 
 	var has_gzip_accept_header = false
-	if response_headers.find("Content-Encoding: gzip") != -1:
-		has_gzip_accept_header = true
+	if Engine.get_version_info().hex >= 0x030500: # Godot 3.5 or higher
+		if response_headers.find("Content-Encoding: gzip") != -1:
+			has_gzip_accept_header = true
+	else:
+		for header in response_headers:
+			if "Content-Encoding: gzip" in header:
+				print("set geader")
+				has_gzip_accept_header = true
 
 	var response_body_decompressed = response_body
 	if has_gzip_accept_header:


### PR DESCRIPTION
did not work for versions prior to Godot 3.5