### PR TITLE
fix(login): reset stay_logged_in after logout

### DIFF
--- a/Scenes/Login.gd
+++ b/Scenes/Login.gd
@@ -121,6 +121,8 @@ func _on_LogoutButton_pressed():
 	PlayFabManager.forget_login()
 	$LoggedIn.hide()
 	update_login_button_states()
+	PlayFabManager.client_config.stay_logged_in = false
+	$Login/StayLoggedInCheckbox.button_pressed = false
 	$Login.show()
 
 


### PR DESCRIPTION
Reset the stay_logged_in flag and uncheck the checkbox when the user logs out.

This keeps the persisted login state synchronized with the UI state and avoids confusing behavior where stay_logged_in remains enabled after logout.

Closes #131