### PR TITLE
Drop "Azure" from PlayFab branding references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 
 # godot-playfab - for Godot 4!
-is an [Azure PlayFab](https://playfab.com) addon for the [Godot Engine](https://godotengine.org/). While it is very early, it is supposed to be two things:
+is a [PlayFab](https://playfab.com) addon for the [Godot Engine](https://godotengine.org/). While it is very early, it is supposed to be two things:
 
-1. A GDScript-native SDK to Azure PlayFab
+1. A GDScript-native SDK to PlayFab
 2. A Godot Editor integration to administer your game
 
 > **Note:**

--- a/addons/godot-playfab/plugin.cfg
+++ b/addons/godot-playfab/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="godot-playfab"
-description="Integration with Azure PlayFab - playfab.com"
+description="Integration with PlayFab - playfab.com"
 author="Johannes Ebner"
 version="1.3.1"
 script="PlayFabEditor.gd"


### PR DESCRIPTION
Azure PlayFab has been rebranded to just PlayFab, so the addon's user-facing text should follow suit.

## What changed
- **README.md** — intro now reads "is a [PlayFab] addon..." and the SDK bullet drops the "Azure" prefix.
- **plugin.cfg** — plugin description is now "Integration with PlayFab - playfab.com".

## What deliberately did not change
The literal `"AzurePlayFab"` Steam Web API identity string (used in `Steam.getAuthTicketForWebApi("AzurePlayFab")`, the Steam docs, and the `LoginWithSteamRequest.gd` comment) is left untouched. That value is a functional integration contract that must match PlayFab's Steam add-on "Identity" config, so renaming it could break Steam authentication. This PR is branding-only.